### PR TITLE
[FIX] fix error when loading bootstrap functions

### DIFF
--- a/pong/config/webpack/environment.js
+++ b/pong/config/webpack/environment.js
@@ -1,6 +1,10 @@
-const { environment } = require('@rails/webpacker');
+import jquery from 'jquery';
 
+const { environment } = require('@rails/webpacker');
 const webpack = require('webpack');
+
+window.$ = jquery;
+window.jquery = jquery;
 
 environment.plugins.prepend(
   'Provide',


### PR DESCRIPTION
this fixes when we call $('#ok-modal-view').modal,
'modal is not a functions' message