### PR TITLE
[FIX] fix bootstrap issue with 'jquery' and 'jquery/src/jquery'

### DIFF
--- a/pong/app/javascript/packs/application.js
+++ b/pong/app/javascript/packs/application.js
@@ -5,13 +5,16 @@
 
 import Rails from '@rails/ujs';
 import Turbolinks from 'turbolinks';
+import _ from 'underscore';
 import $ from 'jquery/src/jquery';
-import 'bootstrap';
 import jquery from 'jquery';
+import 'bootstrap';
 import app from '../srcs/app';
 
-window.$ = jquery;
-window.jquery = jquery;
+_.extend($, jquery);
+
+window.$ = $;
+window.jquery = $;
 
 Rails.start();
 Turbolinks.start();


### PR DESCRIPTION
temporarily, we just extend 'jquery' to 'jquery/src/jquery'