### PR TITLE
[ADD] add bootstrap-menu

### DIFF
--- a/pong/package.json
+++ b/pong/package.json
@@ -8,6 +8,7 @@
     "backbone": "^1.4.0",
     "backbone.radio": "^2.0.0",
     "bootstrap": "^4.3.1",
+    "bootstrap-menu": "^1.0.14",
     "jquery": "^3.6.0",
     "jquery-contextmenu": "^2.9.2",
     "jquery-ujs": "^1.2.2",


### PR DESCRIPTION
added bootstrap menu dependency.
below is example

import $ from 'jquery/src/jquery';
import BootstrapMenu from 'bootstrap-menu';
import collection from '../collections';
import common from '../common';
import template from '../templates/ChatRoomCollectionView.html';
import ChatRoomView from './ChatRoomView';

const ChatRoomCollectionView = common.CollectionView.extend({
  template,
  childContainer: '#chatroom-collection',
  ViewType: ChatRoomView,
  CollectionType: collection.ChatRoomCollection,
  onInitialize() {
    this.menu = new BootstrapMenu('.chatroom', {
      actions: [
        {
          name: 'Action',
          onClick: function () {},
          classNames: 'dropdown-item',
        },
        {
          name: 'Another action',
          onClick: function () {},
          classNames: 'dropdown-item',
        },
        {
          name: 'A third action',
          onClick: function () {},
          classNames: 'dropdown-item',
        },
      ],
    });
  },
});

export default ChatRoomCollectionView;