### PR TITLE
[FIX] fix sidebar and text color

### DIFF
--- a/pong/public/css/content-common.css
+++ b/pong/public/css/content-common.css
@@ -2,7 +2,6 @@
   position: absolute;
   width: 100%;
   height: calc(100% - 50px);
-  color: white;
 }
 
 .background-dark {
@@ -16,11 +15,18 @@
   padding: 0 20px;
 }
 
+@media screen and (max-width: 900px) {
+  #content .inner-box {
+    width: 100%;
+  }
+}
+
 #content .inner-box .title {
   height: 35px;
   margin: 20px 0;
   text-align: center;
   font-family: sans-serif;
+  color: white;
 }
 
 #content .inner-box .body {
@@ -29,6 +35,7 @@
   border: 1px solid white;
   background-color: white;
   margin: 0px;
+  color: black;
   height: calc(100% - 35px - 30px - 30px);
   border-radius: 5px;
   box-shadow: rgba(0, 0, 0, 0.25) 0px 0.0625em 0.0625em,


### PR DESCRIPTION
- 화면 크기 줄어들었을 때, 사이드바 영역이 텅 비어있어서 미디어 쿼리로 수정했습니다.
- body 영역이 배경은 흰색인데 텍스트 색도 흰색이라 검정색으로 바꿨습니다.