### PR TITLE
[FIX] test param argument name

### DIFF
--- a/pong/app/controllers/application_controller.rb
+++ b/pong/app/controllers/application_controller.rb
@@ -42,10 +42,10 @@ class ApplicationController < ActionController::Base
   end
 
   def need_second_authenticate(_exception)
-    render json: { type: 'redirect', redirect: 'auth' }, status: :unauthorized
+    render json: { type: 'redirect', target: 'auth' }, status: :unauthorized
   end
 
   def need_first_update(_exception)
-    render json: { type: 'redirect', redirect: 'mypage' }, status: :unauthorized
+    render json: { type: 'redirect', target: 'mypage' }, status: :unauthorized
   end
 end

--- a/pong/app/models/user.rb
+++ b/pong/app/models/user.rb
@@ -97,18 +97,20 @@ class User < ApplicationRecord
 
   def session_create
     update!(status: 'online')
-    FriendChannel.broadcast_to self, { data: serialize, status: :ok }
+    @user_current = User.find id
+    FriendChannel.broadcast_to @user_current, { data: serialize, status: :ok }
   end
 
   def session_destroy
     update!(status: 'offline')
-    FriendChannel.broadcast_to self, { data: serialize, status: :ok }
+    @user_current = User.find id
+    FriendChannel.broadcast_to @user_current, { data: serialize, status: :ok }
   end
 
   private
 
   def serialize
-    self.to_json only: %i[id name nickname status]
+    to_json only: %i[id name nickname status]
   end
 
   def second_initialize

--- a/pong/test/controllers/api/blocks_controller_test.rb
+++ b/pong/test/controllers/api/blocks_controller_test.rb
@@ -16,7 +16,7 @@ module Api
       login :hyeyoo
       to_block = users(:officer)
       assert_difference '@user.reload.blacklist.count', 1 do
-        post api_user_blocks_url(@user.id), params: { blocked_user_id: to_block.id }
+        post api_user_blocks_url(@user.id), params: { id: to_block.id }
         assert_response :created
         assert Block.where(user_id: @user.id, blocked_user_id: to_block.id).exists?
       end
@@ -27,7 +27,7 @@ module Api
       other_user = users(:hyeyoo)
       to_block = users(:officer)
       assert_no_difference 'other_user.reload.blacklist.count', 1 do
-        post api_user_blocks_url(other_user.id), params: { blocked_user_id: to_block.id }
+        post api_user_blocks_url(other_user.id), params: { id: to_block.id }
         assert_response :forbidden
       end
     end

--- a/pong/test/controllers/api/friends_controller_test.rb
+++ b/pong/test/controllers/api/friends_controller_test.rb
@@ -18,7 +18,7 @@ module Api
       login :hyeyoo
       follow_user = users(:master)
       assert_difference '@user.reload.followings.count', 1 do
-        post api_user_friends_url(@user.id), params: { follow_id: follow_user.id }
+        post api_user_friends_url(@user.id), params: { id: follow_user.id }
       end
       assert_response :created
       assert_equal result['follow_id'], follow_user.id
@@ -29,7 +29,7 @@ module Api
       other_user = users(:officer)
       follow_user = users(:master)
       assert_no_difference 'other_user.reload.followings.count' do
-        post api_user_friends_url(other_user.id), params: { follow_id: follow_user.id }
+        post api_user_friends_url(other_user.id), params: { id: follow_user.id }
       end
       assert_response :forbidden
     end


### PR DESCRIPTION
1. Friend 채널에 broadcast 하는 모델 메소드를 조금 손봤습니다
2. block/friend 에서 사용되는 param 의 argument 이름(키값)을 수정한 대로 고쳤습니다.
3. 에러 포맷에서 type: redirect, target: blahblah 로 바꿨습니다

2번이 반영되면 테스트가 다시 잘 될거예요