### PR TITLE
Feature/backend guild index 수정

### DIFF
--- a/pong/app/assets/stylesheets/api/games.scss
+++ b/pong/app/assets/stylesheets/api/games.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the api/games controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/pong/app/controllers/api/games_controller.rb
+++ b/pong/app/controllers/api/games_controller.rb
@@ -1,0 +1,42 @@
+module Api
+  class GamesController < ApplicationController
+    before_action :authenticate_user!
+
+    def index
+      render json: Game.all
+    end
+
+    def show
+      @game = Game.find params[:id]
+      render json: @game
+    end
+
+    def create
+      availability_check
+      @new_queue = GameQueue.create(queue_params)
+      # TODO : wait OR start game
+      render json: {}, status: :no_content
+    end
+
+    def cancel
+      find_queue current_user.id
+    end
+
+    private
+
+    def availability_check
+      return false unless GameQueue.playable?(current_user)
+
+      return false if params[:user_id].blank? && GameQueue.playable?(User.find(params[:user_id]))
+      # type check
+    end
+
+    def queue_params
+      params.permit(:game_type, :addon, :user_id)
+    end
+
+    def find_queue(id)
+      @queue = GameQueue.find_by user_id: id
+    end
+  end
+end

--- a/pong/app/controllers/api/guild_members_controller.rb
+++ b/pong/app/controllers/api/guild_members_controller.rb
@@ -4,7 +4,8 @@ module Api
 
     def index
       guild = Guild.find(params[:guild_id])
-      render json: guild.members, status: :ok
+      @members = guild.guild_member_relationship
+      render status: :ok
     end
 
     def update

--- a/pong/app/helpers/api/games_helper.rb
+++ b/pong/app/helpers/api/games_helper.rb
@@ -1,0 +1,4 @@
+module Api
+  module GamesHelper
+  end
+end

--- a/pong/app/models/game_queue.rb
+++ b/pong/app/models/game_queue.rb
@@ -1,4 +1,7 @@
 class GameQueue < ApplicationRecord
+  # enum
+  enum game_type: Game.game_types
+
   # validations
   validates :game_type, inclusion: { in: Game.game_types.keys }
   validates :user_id, uniqueness: true

--- a/pong/app/models/game_queue.rb
+++ b/pong/app/models/game_queue.rb
@@ -5,4 +5,9 @@ class GameQueue < ApplicationRecord
   # validations
   validates :game_type, inclusion: { in: Game.game_types.keys }
   validates :user_id, uniqueness: true
+
+  # methods
+  def self.playable?(user)
+    user.status == 'online'
+  end
 end

--- a/pong/app/models/guild_member.rb
+++ b/pong/app/models/guild_member.rb
@@ -13,6 +13,7 @@ class GuildMember < ApplicationRecord
 
   # methods
   def self.update_check(user, member, target_role)
+    return {} if User.roles[user.role].positive?
     user_member = GuildMember.find_by(user_id: user.id)
     result = {}
     if user_member.guild.id != member.guild.id || user_member.role != 'master'

--- a/pong/app/models/guild_member.rb
+++ b/pong/app/models/guild_member.rb
@@ -18,9 +18,9 @@ class GuildMember < ApplicationRecord
 
     user_member = GuildMember.find_by(user_id: user.id)
     if user_member.guild.id != member.guild.id || user_member.role != 'master'
-      result = set_result('you cannot change the role of other members.', :forbidden)
+      result = { 'message' => 'you cannot change the role of other members.', 'status' => :forbidden }
     elsif member.role == 'master' || target_role == 'master'
-      result = set_result('master is immutable role.', :bad_request)
+      result = { 'message' => 'master is immutable role.', 'status' => :bad_request }
     end
     result
   end
@@ -36,11 +36,5 @@ class GuildMember < ApplicationRecord
     else
       user.id == member.user_id
     end
-  end
-
-  private
-
-  def set_result(message, status)
-    { 'message' => message, 'status' => status }
   end
 end

--- a/pong/app/models/guild_member.rb
+++ b/pong/app/models/guild_member.rb
@@ -13,15 +13,14 @@ class GuildMember < ApplicationRecord
 
   # methods
   def self.update_check(user, member, target_role)
-    return {} if User.roles[user.role].positive?
-    user_member = GuildMember.find_by(user_id: user.id)
     result = {}
+    return result if User.roles[user.role].positive?
+
+    user_member = GuildMember.find_by(user_id: user.id)
     if user_member.guild.id != member.guild.id || user_member.role != 'master'
-      result['message'] = 'you cannot change the role of other members.'
-      result['status'] = :forbidden
+      result = set_result('you cannot change the role of other members.', :forbidden)
     elsif member.role == 'master' || target_role == 'master'
-      result['message'] = 'master is immutable role.'
-      result['status'] = :bad_request
+      result = set_result('master is immutable role.', :bad_request)
     end
     result
   end
@@ -37,5 +36,11 @@ class GuildMember < ApplicationRecord
     else
       user.id == member.user_id
     end
+  end
+
+  private
+
+  def set_result(message, status)
+    { 'message' => message, 'status' => status }
   end
 end

--- a/pong/app/views/api/guild_members/index.json.jbuilder
+++ b/pong/app/views/api/guild_members/index.json.jbuilder
@@ -1,0 +1,9 @@
+json.array! @members do |member|
+  json.id member.id
+  json.role member.role
+  json.user do
+    json.id member.user.id
+    json.name member.user.name
+    json.nickname member.user.nickname
+  end
+end

--- a/pong/config/routes.rb
+++ b/pong/config/routes.rb
@@ -41,8 +41,11 @@ Rails.application.routes.draw do
     end
 
     # matchmaking & game
-    resources :games, only: %i[index create show]
-    resource :games, only: :destroy
+    resources :games, only: %i[index create show] do
+      collection do
+        delete 'cancel'
+      end
+    end
 
     resources :chat_rooms, path: 'chatrooms', only: %i[index update destroy create] do
       resources :chat_rooms_members, path: 'members', only: %i[index update destroy create]

--- a/pong/config/routes.rb
+++ b/pong/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: { format: :json } do
     post 'auth', to: 'auth#match'
+
     resources :users, only: %i[index show update] do
       collection do
         get 'rank'
@@ -27,6 +28,7 @@ Rails.application.routes.draw do
       resources :blocks, only: %i[index create destroy], param: :id
       resources :invites, only: %i[index create update destroy]
     end
+
     resources :guilds, only: %i[index show create destroy] do
       collection do
         get 'rank'
@@ -37,6 +39,11 @@ Rails.application.routes.draw do
       end
       resources :members, only: %i[index update destroy], controller: 'guild_members', param: :user_id
     end
+
+    # matchmaking & game
+    resources :games, only: %i[index create show]
+    resource :games, only: :destroy
+
     resources :chat_rooms, path: 'chatrooms', only: %i[index update destroy create] do
       resources :chat_rooms_members, path: 'members', only: %i[index update destroy create]
       resources :chat_room_messages, path: 'messages', only: %i[index]

--- a/pong/db/migrate/20210507120649_add_target_id_column_to_game_queue.rb
+++ b/pong/db/migrate/20210507120649_add_target_id_column_to_game_queue.rb
@@ -1,0 +1,5 @@
+class AddTargetIdColumnToGameQueue < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :game_queues, :target, null: true, foreign_key: { to_table: :users }
+  end
+end

--- a/pong/db/schema.rb
+++ b/pong/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_06_100230) do
+ActiveRecord::Schema.define(version: 2021_05_07_120649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,8 @@ ActiveRecord::Schema.define(version: 2021_05_06_100230) do
     t.boolean "addon", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "target_id"
+    t.index ["target_id"], name: "index_game_queues_on_target_id"
     t.index ["user_id"], name: "index_game_queues_on_user_id", unique: true
   end
 
@@ -199,6 +201,7 @@ ActiveRecord::Schema.define(version: 2021_05_06_100230) do
   add_foreign_key "game_players", "games"
   add_foreign_key "game_players", "users"
   add_foreign_key "game_queues", "users"
+  add_foreign_key "game_queues", "users", column: "target_id"
   add_foreign_key "guild_members", "guilds"
   add_foreign_key "guild_members", "users"
   add_foreign_key "invites", "guilds"

--- a/pong/test/controllers/api/games_controller_test.rb
+++ b/pong/test/controllers/api/games_controller_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+module Api
+  class GamesControllerTest < ActionDispatch::IntegrationTest
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end

--- a/pong/test/controllers/api/guild_members_controller_test.rb
+++ b/pong/test/controllers/api/guild_members_controller_test.rb
@@ -26,6 +26,22 @@ module Api
       assert_equal result['role'], 'officer'
     end
 
+    test "guild member update successfully with admin" do
+      login :admin
+      member = users(:member)
+      put "/api/guilds/#{@guild.id}/members/#{member.id}", params: { role: 'officer' }
+      assert_response :success
+      assert_equal result['role'], 'officer'
+    end
+
+    test "guild member update successfully with owner" do
+      login :owner
+      member = users(:member)
+      put "/api/guilds/#{@guild.id}/members/#{member.id}", params: { role: 'officer' }
+      assert_response :success
+      assert_equal result['role'], 'officer'
+    end
+
     test "guild member update with member" do
       login :member
       officer = users(:officer)
@@ -51,6 +67,24 @@ module Api
 
     test "guild normal member destroy by master" do
       login :master
+      member = users(:member)
+      assert_difference '@guild.members.count', -1 do
+        delete "/api/guilds/#{@guild.id}/members/#{member.id}"
+      end
+      assert_response :success
+    end
+
+    test "guild normal member destroy by owner" do
+      login :owner
+      member = users(:member)
+      assert_difference '@guild.members.count', -1 do
+        delete "/api/guilds/#{@guild.id}/members/#{member.id}"
+      end
+      assert_response :success
+    end
+
+    test "guild normal member destroy by admin" do
+      login :admin
       member = users(:member)
       assert_difference '@guild.members.count', -1 do
         delete "/api/guilds/#{@guild.id}/members/#{member.id}"

--- a/pong/test/controllers/api/guilds_controller_test.rb
+++ b/pong/test/controllers/api/guilds_controller_test.rb
@@ -93,6 +93,24 @@ module Api
       assert_response :no_content
     end
 
+    test 'guild destroy with owner' do
+      login :owner
+      guild = guilds(:test)
+      assert_difference 'Guild.count', -1 do
+        delete "/api/guilds/#{guild.id}"
+      end
+      assert_response :no_content
+    end
+
+    test 'guild destroy with admin' do
+      login :owner
+      guild = guilds(:test)
+      assert_difference 'Guild.count', -1 do
+        delete "/api/guilds/#{guild.id}"
+      end
+      assert_response :no_content
+    end
+
     test 'guild destroy member_with_reload' do
       login :master
       guild = guilds(:test)

--- a/pong/test/fixtures/games.yml
+++ b/pong/test/fixtures/games.yml
@@ -4,6 +4,3 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-duel_one:
-    game_type: 0
-    addon: false


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59996142/117521757-6e241a80-afea-11eb-92c3-eb0cd1cfb4af.png)

이렇게 `http://localhost:3000/api/guilds/길드ID/members` 로 길드 멤버 리스트를 받아오게 되면

```
[{id: MEMBER_ID, role: MEMBER_ROLE, user: {id: USER_ID, name: USER_NAME, nickname: USER_NICKNAME} }]
```
처럼 길드에서의 직위(role) 가 드러나게 수정했습니다