### PR TITLE
[FIX] bug about params string compare with boolean

### DIFF
--- a/pong/app/controllers/api/users_controller.rb
+++ b/pong/app/controllers/api/users_controller.rb
@@ -26,7 +26,7 @@ module Api
       @user = User.find(params[:id])
       raise User::PermissionDenied unless current_user.id == @user.id
 
-      if @user.is_email_auth && !@user.auth_confirmed? && params[:is_email_auth] == false
+      if @user.is_email_auth && !@user.auth_confirmed? && params[:is_email_auth] == 'false'
         error_msg = { type: "message", message: 'you cannot disable 2FA when have to do secondary authenticate.' }
         render json: error_msg, status: :unauthorized and return
       end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59996142/117768879-f6662200-b26d-11eb-9d13-f6fe7cbbba12.png)


고쳤습니다...


![image](https://user-images.githubusercontent.com/59996142/117768924-08e05b80-b26e-11eb-910a-5ec1b85cee42.png)


params 는 언제나 string 인 거 같습니다