### PR TITLE
Feature/backend matchmaking cancel 동작 변경

### DIFF
--- a/pong/app/controllers/api/games_controller.rb
+++ b/pong/app/controllers/api/games_controller.rb
@@ -20,11 +20,11 @@ module Api
     def cancel
       GameQueue.with_advisory_lock('queue') do
         find_queue current_user.id
-        unless @queue.target_id.nil?
+        unless @queue.nil? || @queue.target_id.nil?
           match_refuse(@queue.user_id, @queue.target_id)
           send_signal(@user.id, { type: 'refuse' })
         end
-        @queue.destroy
+        @queue&.destroy
       end
       render json: {}, status: :no_content
     end
@@ -95,9 +95,9 @@ module Api
 
     def find_queue(id)
       @queue = if GameQueue.where(user_id: id).exists?
-                 GameQueue.where(user_id: id).first!
+                 GameQueue.where(user_id: id).first
                else
-                 GameQueue.where(target_id: id).first!
+                 GameQueue.where(target_id: id).first
                end
     end
 

--- a/pong/test/controllers/api/games_controller_test.rb
+++ b/pong/test/controllers/api/games_controller_test.rb
@@ -19,5 +19,12 @@ module Api
         post api_games_url, params: { game_type: 'friendly', addon: false }
       end
     end
+
+    test "canceling request always success" do
+      user = users(:game_test_user)
+      sign_in user
+      delete cancel_api_games_url
+      assert_response :success
+    end
   end
 end

--- a/pong/test/controllers/api/games_controller_test.rb
+++ b/pong/test/controllers/api/games_controller_test.rb
@@ -12,6 +12,18 @@ module Api
       end
     end
 
+    test "accept friendly game" do
+      user = users(:game_test_user)
+      sign_in user
+      opposite = users(:hyekim)
+      GameQueue.create(user_id: opposite.id, game_type: 'friendly', addon: false, target_id: user.id)
+      assert_difference 'Game.count', 1 do
+        post api_games_url, params: { game_type: 'friendly', addon: false }
+      end
+      assert_response :success
+      assert_equal GamePlayer.count, 2
+    end
+
     test "accepted friendly but requester canceled" do
       user = users(:game_test_user)
       sign_in user
@@ -24,6 +36,19 @@ module Api
       user = users(:game_test_user)
       sign_in user
       delete cancel_api_games_url
+      assert_response :success
+    end
+
+    test "wait and cancel" do
+      user = users(:game_test_user)
+      sign_in user
+      assert_difference 'GameQueue.count', 1 do
+        post api_games_url, params: { game_type: 'duel', addon: false }
+      end
+      assert_response :success
+      assert_difference 'GameQueue.count', -1 do
+        delete cancel_api_games_url
+      end
       assert_response :success
     end
   end


### PR DESCRIPTION
이제 아무것도 없는(나에게 온 게임 요청 or 내가 한 큐 대기) 상태에서 매치메이킹 캔슬을 해도 성공이 반환 됨

테스트 약간 추가