### PR TITLE
[ADD] Make  user history view work

### DIFF
--- a/pong/app/javascript/srcs/templates/SideView.html
+++ b/pong/app/javascript/srcs/templates/SideView.html
@@ -161,11 +161,7 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <div
-        class="modal-body"
-        id="chatroom-user-collection"
-        style="overflow-y: scroll"
-      >
+      <div class="modal-body" id="chatroom-user-collection">
         <div id="user-info"></div>
         <div class="profile button"></div>
         <div id="user-history"></div>

--- a/pong/app/javascript/srcs/templates/UserHistoryCollectionView.html
+++ b/pong/app/javascript/srcs/templates/UserHistoryCollectionView.html
@@ -1,6 +1,17 @@
-<div
-  class="card"
-  style="min-height: 150px; max-height: 150px; overflow-y: scroll"
+<table
+  class="table-striped table-bordered"
+  style="width: 100%; margin: 0; padding: 0"
 >
-  <div id="user-history-collection"></div>
-</div>
+  <thead>
+    <tr style="text-align: center">
+      <th scope="col">Opposite</th>
+      <th scope="col">Result</th>
+      <th scope="col">Score</th>
+      <th scope="col">Game Type</th>
+    </tr>
+  </thead>
+  <tbody
+    id="user-history-collection"
+    style="overflow: scroll; text-align: center"
+  ></tbody>
+</table>

--- a/pong/app/javascript/srcs/templates/UserHistoryCollectionView.html
+++ b/pong/app/javascript/srcs/templates/UserHistoryCollectionView.html
@@ -10,8 +10,5 @@
       <th scope="col">Game Type</th>
     </tr>
   </thead>
-  <tbody
-    id="user-history-collection"
-    style="overflow: scroll; text-align: center"
-  ></tbody>
+  <tbody id="user-history-collection" style="text-align: center"></tbody>
 </table>

--- a/pong/app/javascript/srcs/templates/UserHistoryView.html
+++ b/pong/app/javascript/srcs/templates/UserHistoryView.html
@@ -1,4 +1,4 @@
 <td><%= opposite_user.nickname %></td>
-<td><%= my_score %></td>
 <td><%= (my_score > opposite_score) ? 'win' : 'lose' %></td>
+<td><%= my_score %>:<%= opposite_score %></td>
 <td><%= game_type %></td>

--- a/pong/app/javascript/srcs/templates/UserHistoryView.html
+++ b/pong/app/javascript/srcs/templates/UserHistoryView.html
@@ -1,1 +1,4 @@
-<div>id:<%= id %></div>
+<td><%= opposite_user.nickname %></td>
+<td><%= my_score %></td>
+<td><%= (my_score > opposite_score) ? 'win' : 'lose' %></td>
+<td><%= game_type %></td>

--- a/pong/app/javascript/srcs/views/UserHistoryView.js
+++ b/pong/app/javascript/srcs/views/UserHistoryView.js
@@ -3,6 +3,7 @@ import template from '../templates/UserHistoryView.html';
 
 const UserHistoryView = common.View.extend({
   template,
+  tagName: 'tr',
   onRender() {},
 });
 


### PR DESCRIPTION
It didn't display properly. So made it display
Opposite(nickname), Result (win/lose), Score (x:y), Game Type (ladder...etc)

Note: Set style overflow: scroll, but it's not tested.
So When histories are too many, it can be ugly