### PR TITLE
Feature/backend matchmaking 수정

### DIFF
--- a/pong/app/controllers/api/games_controller.rb
+++ b/pong/app/controllers/api/games_controller.rb
@@ -12,7 +12,8 @@ module Api
     end
 
     def create
-      # render json: { type: 'message', message: 'not playable!' }, status: :conflict and return unless availability_check
+      # render json: { type: 'message', message: 'not playable!' },
+      # status: :conflict and return unless availability_check
 
       match_make
       render json: {}, status: :no_content
@@ -67,9 +68,9 @@ module Api
       when 'duel', 'ladder', 'ladder_tournament', 'friendly'
         basic_matchmaking
       when 'tournament'
-        tournament_matchmaking
-      else # war
-        war_matchmaking
+        tournament_matchmaking and return
+      else
+        war_matchmaking and return
       end
       game_start(@game) unless @game.nil?
     end
@@ -88,12 +89,12 @@ module Api
 
     def tournament_matchmaking
       # TODO : Tournament.first
-      render json: {}, status: :not_implemented
+      render json: {}, status: :not_implemented and return
     end
 
     def war_matchmaking
       # TODO : War.current
-      render json: {}, status: :not_implemented
+      render json: {}, status: :not_implemented and return
     end
 
     def find_queue(id)

--- a/pong/app/controllers/api/games_controller.rb
+++ b/pong/app/controllers/api/games_controller.rb
@@ -12,7 +12,8 @@ module Api
     end
 
     def create
-      availability_check
+      render json: { type: 'message', message: 'not playable!' }, status: :conflict and return unless availability_check
+
       match_make
       render json: {}, status: :no_content
     end
@@ -40,7 +41,9 @@ module Api
 
     def availability_check
       # if target is exist, check if target user is playable.
-      return GameQueue.playable?(User.find(params[:target_id])) unless params[:target_id].nil?
+      return false if !params[:target_id].nil? && !GameQueue.playable?(User.find(params[:target_id]))
+
+      # return GameQueue.playable?(User.find(params[:target_id])) unless params[:target_id].nil?
 
       # self playable check
       GameQueue.playable?(current_user)

--- a/pong/app/controllers/api/games_controller.rb
+++ b/pong/app/controllers/api/games_controller.rb
@@ -12,7 +12,7 @@ module Api
     end
 
     def create
-      render json: { type: 'message', message: 'not playable!' }, status: :conflict and return unless availability_check
+      # render json: { type: 'message', message: 'not playable!' }, status: :conflict and return unless availability_check
 
       match_make
       render json: {}, status: :no_content

--- a/pong/app/helpers/application_helper.rb
+++ b/pong/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
 
   def check_signal_format(data)
     type = data[:type]
-    raise SignalChannel::InvalidFormat unless %w[connect fetch refuse].include?(type)
+    raise SignalChannel::InvalidFormat unless %w[connect fetch refuse request].include?(type)
 
     raise SignalChannel::InvalidFormat if type == 'connect' && data[:game_id].nil?
 

--- a/pong/app/jobs/queue_timeover_job.rb
+++ b/pong/app/jobs/queue_timeover_job.rb
@@ -5,7 +5,7 @@ class QueueTimeoverJob < ApplicationJob
     return if GameQueue.where(id: queue_id).empty?
 
     queue = GameQueue.where(id: queue_id).first!
-    requested_user = queue.user_id
+    requested_user = User.find queue.user_id
     queue.destroy!
 
     requested_user.status_update('online') if requested_user.reload.status != 'offline'

--- a/pong/app/jobs/queue_timeover_job.rb
+++ b/pong/app/jobs/queue_timeover_job.rb
@@ -5,7 +5,7 @@ class QueueTimeoverJob < ApplicationJob
     return if GameQueue.where(id: queue_id).empty?
 
     queue = GameQueue.where(id: queue_id).first!
-    requested_user = GameQueue.user_id
+    requested_user = queue.user_id
     queue.destroy!
 
     requested_user.status_update('online') if requested_user.reload.status != 'offline'


### PR DESCRIPTION
* availability_check 가 올바른 결과를 반환하고, 또 이를 이용해 (참가대상자의 상태가 게임 신청 혹은 게임신청을 받기에 적절하지 않은 경우) 409 conflict 를 반환하도록 했습니다
* 이제 request 도 올바른 signal type 입니다.
* 대전신청 시간이 지났을 때 자동으로 제거해주는 잡인 QueueTimeoverJob 에서 인스턴스 이름 대신 클래스 이름을 사용해서 나오는 에러를 고쳤습니다. 더블렌더 에러는 왜 뜨는건지 아직 모르겠어요.