### PR TITLE
[FIX] fix wrong use of data

### DIFF
--- a/pong/app/javascript/srcs/views/UserProfileModalView.js
+++ b/pong/app/javascript/srcs/views/UserProfileModalView.js
@@ -117,6 +117,7 @@ const UserProfileModalView = common.View.extend({
       url: `/api/users/${this.userId}/game`,
       headers: auth.getTokenHeader(),
       success(game) {
+        game = game.game;
         Radio.channel('route').trigger(
           'route',
           `play?isHost=false&channelId=${game.id}&addon=${game.addon}`,


### PR DESCRIPTION
Thought the type of '/api/users/${this.userId}/game' is Game,
but it was GamePlayer. so we should get GamePlayer.game.

This is so ambiguous :<