### PR TITLE
토너먼트 조회 생성 api 추가

### DIFF
--- a/pong/app/controllers/api/tournaments_controller.rb
+++ b/pong/app/controllers/api/tournaments_controller.rb
@@ -1,0 +1,32 @@
+module Api
+  class TournamentsController < ApplicationController
+    before_action :authenticate_user!
+
+    def index
+      tournament = Tournament.first
+      if tournament.nil?
+        render json: {}, status: :ok
+      else
+        render json: serialize(tournament), status: :ok
+      end
+    end
+
+    def create
+      raise Tournament::PermissionDenied if current_user.user?
+
+      tournament = Tournament.create! tournament_params
+      render json: serialize(tournament), status: :created
+    end
+
+    private
+
+    def serialize(tournament)
+      data = tournament.as_json
+      data["participants_count"] = tournament.participants.count
+    end
+
+    def tournament_params
+      params.permit :title, :max_participants, :is_ladder, :addon, :start_at
+    end
+  end
+end

--- a/pong/app/controllers/application_controller.rb
+++ b/pong/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   rescue_from Friend::PermissionDenied, with: :error_permission_denied
   rescue_from Block::PermissionDenied, with: :error_permission_denied
   rescue_from User::PermissionDenied, with: :error_permission_denied
+  rescue_from Tournament::PermissionDenied, with: :error_permission_denied
   rescue_from EmailAuth::AuthenticationNotFinished, with: :need_second_authenticate
   rescue_from User::NeedFirstUpdate, with: :need_first_update
   rescue_from User::NotNewcomer, with: :nickname_not_newcomer

--- a/pong/app/models/tournament.rb
+++ b/pong/app/models/tournament.rb
@@ -1,9 +1,25 @@
+class ExistsValidator < ActiveModel::Validator
+  def validate(record)
+    record.errors.add :base, "A tournament already exists" if Tournament.exists?
+  end
+end
+
+class StartAtValidator < ActiveModel::Validator
+  def validate(record)
+    record.errors.add :base, "start_at must be future" if record.start_at <= Time.zone.now + 1.minute
+  end
+end
+
 class Tournament < ApplicationRecord
+  class PermissionDenied < StandardError; end
+
   has_many :tournament_participants, dependent: :destroy
   has_many :participants, through: :tournament_participants, source: :user
 
   after_create :start_later
-
+  validates :max_participants, numericality: { greater_than_or_equal_to: 4 }
+  validates_with ExistsValidator, on: :create
+  # validates_with StartAtValidator
   def start
     start_index = Math.sqrt(tournament_participants.count).ceil.pow(2)
     tournament_participants.shuffle.each_with_index do |participant, index|

--- a/pong/app/models/tournament_participant.rb
+++ b/pong/app/models/tournament_participant.rb
@@ -38,7 +38,7 @@ class TournamentParticipant < ApplicationRecord
   end
 
   def create_game
-    game = Game.create! game_type: :tournament, addon: tournament.is_addon
+    game = Game.create! game_type: :tournament, addon: tournament.addon
     GamePlayer.create! game_id: game.id, user_id: user_id, is_host: true
     GamePlayer.create! game_id: game.id, user_id: opponent.user_id, is_host: false
     game.game_players.each do |player|

--- a/pong/config/routes.rb
+++ b/pong/config/routes.rb
@@ -66,8 +66,7 @@ Rails.application.routes.draw do
       put '/members', to: 'dm_rooms_members#update'
       resources :dm_room_messages, path: 'messages', only: %i[index]
     end
-    resources :tournaments, only: [] do
-      resources :tournament_participants, path: 'participants', only: %i[create]
-    end
+    resources :tournaments, only: %i[create index]
+    resources :tournament_participants, path: 'tournaments/participants', only: %i[create]
   end
 end

--- a/pong/db/migrate/20210601045252_change_tournament_column_name.rb
+++ b/pong/db/migrate/20210601045252_change_tournament_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeTournamentColumnName < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :tournaments, :is_addon, :addon
+  end
+end

--- a/pong/db/schema.rb
+++ b/pong/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_01_045251) do
+ActiveRecord::Schema.define(version: 2021_06_01_045252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -219,7 +219,7 @@ ActiveRecord::Schema.define(version: 2021_06_01_045251) do
     t.string "title", null: false
     t.integer "max_participants", default: 4, null: false
     t.boolean "is_ladder", default: false
-    t.boolean "is_addon", default: false
+    t.boolean "addon", default: false
     t.datetime "start_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/pong/test/controllers/api/tournament_controller_test.rb
+++ b/pong/test/controllers/api/tournament_controller_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+require "json"
+
+module Api
+  class TournamentControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    setup do
+      sign_in users(:hyekim)
+    end
+
+    test "index" do
+      get api_tournaments_path, as: :json
+      assert_response :ok
+    end
+
+    test "create" do
+      post api_tournaments_path, as: :json,
+                                 params: { title: "RUBY", is_ladder: false, addon: false,
+                                           max_participants: 8, start_at: (Time.zone.now + 3.hours) }
+      assert_response :forbidden
+      sign_in users(:owner)
+
+      post api_tournaments_path, as: :json
+      assert_response :bad_request
+      tournament = tournaments :tournament1
+      tournament.destroy!
+
+      post api_tournaments_path, as: :json,
+                                 params: { title: "RUBY", is_ladder: false, addon: false,
+                                           max_participants: 8, start_at: (Time.zone.now + 3.hours) }
+      assert_response :created
+    end
+  end
+end

--- a/pong/test/controllers/api/tournament_participants_controller_test.rb
+++ b/pong/test/controllers/api/tournament_participants_controller_test.rb
@@ -13,7 +13,7 @@ module Api
     test "create" do
       tournament = tournaments :tournament1
       before_conut = tournament.participants.count
-      post api_tournament_tournament_participants_path(tournament.id), as: :json
+      post api_tournament_participants_path(tournament.id), as: :json
       assert_response :created
       after_count = tournament.participants.count
       assert_equal before_conut + 1, after_count

--- a/pong/test/fixtures/tournaments.yml
+++ b/pong/test/fixtures/tournaments.yml
@@ -7,6 +7,6 @@
 tournament1:
     title: "tournament1"
     is_ladder: false
-    is_addon: false
+    addon: false
     max_participants: 8
     start_at: <%= 5.hours.after %>


### PR DESCRIPTION
GET /api/tournaments
POST /api/tournaments 
토너먼트 조회, 생성 api추가
토너먼트에서 start_at validation이 제대로 작동하지 않는 문제가 있어서 주석처리했습니다.