### PR TITLE
[FIX] Fix tournament router bug

### DIFF
--- a/pong/app/javascript/srcs/game/GameReceiver.js
+++ b/pong/app/javascript/srcs/game/GameReceiver.js
@@ -103,6 +103,8 @@ class GameReceiver {
             self.bars[0].update();
             self.bars[1].update();
             self.simulate();
+          } else if (data.type === 'continue') {
+            Radio.channel('route').trigger('route', 'loading');
           }
         },
       },


### PR DESCRIPTION
In commit '23a542cd01 ('[UPDATE] Passing game data in uri is bad')',
changed method passing game data, from URI to radio.

But it caused a problem. When you win a tournament round,
it redirects to 'play', in route 'play'. routing to same
route does nothing in Backbone. (It was okay before, because
the route was 'play?channelId=XXXX....'. it was unique)

Fix it by routing to loading page when you win a round