### PR TITLE
[FIX] Show spectator modal instead of win/lose modal to spectator

### DIFF
--- a/pong/app/javascript/srcs/game/GameReceiver.js
+++ b/pong/app/javascript/srcs/game/GameReceiver.js
@@ -16,7 +16,7 @@ import view from '../views';
  */
 
 class GameReceiver {
-  constructor(canvasId, channelId, addon, isHost) {
+  constructor(canvasId, channelId, addon, isHost, isSpectator) {
     this.isStarted = true;
     this.winner = null;
     this.score1 = 0;
@@ -64,7 +64,12 @@ class GameReceiver {
           if (!data || !data.type) return;
           if (data.type === 'end') {
             self.connection.unsubscribe();
-            if (
+            if (isSpectator) {
+              new view.OkModalView().show(
+                'Game ended!',
+                'Game ended. Was spectating fun?',
+              );
+            } else if (
               (isHost && data.winner === 1) ||
               (!isHost && data.winner === 2)
             ) {

--- a/pong/app/javascript/srcs/views/GamePlayView.js
+++ b/pong/app/javascript/srcs/views/GamePlayView.js
@@ -16,6 +16,7 @@ const GuildWarTimeModalView = common.View.extend({
     this.is_host = obj.is_host;
     this.game_id = obj.game_id;
     this.addon = obj.addon;
+    this.is_spectator = obj.is_spectator;
     this.gameObjects = [];
   },
   onRender() {
@@ -38,6 +39,7 @@ const GuildWarTimeModalView = common.View.extend({
         this.game_id,
         this.addon,
         true,
+        this.is_spectator,
       );
       self.disconnected = false;
       self.gameObjects.push(receiver);
@@ -58,6 +60,7 @@ const GuildWarTimeModalView = common.View.extend({
         this.game_id,
         this.addon,
         false,
+        this.is_spectator,
       );
       self.gameObjects.push(receiver);
     }

--- a/pong/app/javascript/srcs/views/UserProfileModalView.js
+++ b/pong/app/javascript/srcs/views/UserProfileModalView.js
@@ -132,6 +132,7 @@ const UserProfileModalView = common.View.extend({
       url: `/api/users/${this.userId}/game`,
       headers: auth.getTokenHeader(),
       success(game) {
+        game.is_spectator = true;
         Radio.channel('game').request('set', game);
         Radio.channel('route').trigger('route', `play?game_id=${game.game_id}`);
       },


### PR DESCRIPTION
modal after game end is always one of WIN or LOSE for everyone.
But that doesn't make sense to spectator. Show modal for spectator.

This commit closes #301