### PR TITLE
Feature/user auth시 500(Object object) 에러 해결

### DIFF
--- a/pong/app/controllers/application_controller.rb
+++ b/pong/app/controllers/application_controller.rb
@@ -28,8 +28,10 @@ class ApplicationController < ActionController::Base
 
     return unless current_user.is_email_auth
 
-    current_user.issue_auth_code if current_user.auth.nil?
-    raise EmailAuth::AuthenticationNotFinished unless current_user.auth_confirmed?
+    User.with_advisory_lock('AUTH') do
+      current_user.issue_auth_code if current_user.auth.nil?
+      raise EmailAuth::AuthenticationNotFinished unless current_user.auth_confirmed?
+    end
   end
 
   def check_banned


### PR DESCRIPTION
auth에 관련된 메소드에 전부 락을 걸어서 같은 id에 대해 두번 2fa 데이터를 발행하려는 시도를 차단했습니다.