### PR TITLE
[FIX] Fix finding game after its deletion

### DIFF
--- a/pong/app/channels/game_channel.rb
+++ b/pong/app/channels/game_channel.rb
@@ -101,7 +101,7 @@ class GameChannel < ApplicationCable::Channel
 
   def unsubscribed
     return current_user.status_update(:online) if spectator?
-    return if @game.reload.nil?
+    return true unless Game.exists? @game.id
 
     if host?
       receive_end({ "scores" => [0, 3], "type" => "end", "winner" => 2 })


### PR DESCRIPTION
Server calls receive_end, which removes game. (when host unsubscribed)
but when non-host player unsubscribes, it tries to find game that
does not exist.

Make unsubscribe always succeed